### PR TITLE
This commit adds a shellcheck job.

### DIFF
--- a/src/shellcheck/@shellcheck.yaml
+++ b/src/shellcheck/@shellcheck.yaml
@@ -1,0 +1,4 @@
+version: 2.1
+description: |
+  Orb for shellcheck. Provides shellcheck to check shell scripts.
+  Source repo https://github.com/heroku/circle-orbs/tree/master/src/shellcheck

--- a/src/shellcheck/examples/everything.yml
+++ b/src/shellcheck/examples/everything.yml
@@ -1,0 +1,13 @@
+description: shellcheck it
+
+usage:
+  version: 2.1
+  orbs:
+    shellcheck: heroku/shellcheck@latest
+
+  workflows:
+    ci:
+      jobs:
+        - shellcheck/shellcheck:
+            paths: scripts internal
+          

--- a/src/shellcheck/executors/shellcheck.yml
+++ b/src/shellcheck/executors/shellcheck.yml
@@ -1,0 +1,8 @@
+docker:
+  - image: heroku/shellcheck:<< parameters.tag >>
+parameters:
+  tag:
+    description: tag of the `heroku/shellcheck` docker image to use (Defaults to 'latest')
+    type: string
+    default: latest
+resource_class: small

--- a/src/shellcheck/jobs/shellcheck.yml
+++ b/src/shellcheck/jobs/shellcheck.yml
@@ -1,0 +1,20 @@
+description: shellcheck job
+executor:
+  name: shellcheck
+  tag: << parameters.version >>
+parameters:
+  version:
+    description: version of shellcheck to use (Defaults to 'latest''; must be a valid docker heroku/shellcheck tag)
+    type: string
+    default: latest
+  paths:
+    description: Space separated list of root paths to search for shell scripts in. (Defaults to `.')
+    type: string
+    default: .
+steps:
+  - checkout
+  - run:
+      command: |
+        for path in << parameters.paths >>; do
+           shellcheck $(find $path -name '*.sh')
+        done


### PR DESCRIPTION
The shellcheck job runs the shellcheck linting command on the provided root directory paths where shell scripts are present. Usage relies on the heroku/shellcheck docker image.