### PR TITLE
golang: extract top-level race-detector config for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The directories require [packing](https://circleci.com/docs/2.0/creating-orbs/#p
 
 Example: `src/golang` contains the source for the heroku/golang orb.
 
+### Dependencies
+
+You will need the `circleci` cli which can be installed with `brew install circleci` on macOS or by following [CircleCI's instructions](https://circleci.com/docs/2.0/local-cli/#installation).
+
 ### Validating an orb
 
 While hacking on an orb you will want to validate it every so often. The Makefile target `validate` will pack the

--- a/src/golang/jobs/test-nodb.yml
+++ b/src/golang/jobs/test-nodb.yml
@@ -23,14 +23,18 @@ parameters:
     description: cover mode (Defaults to 'atomic')
     type: string
     default: atomic
+  race-detector:
+    description: Controls race detector (Defaults to 'true')
+    type: boolean
+    default: true
   pkg-spec:
     description: Spec of packages to test (Defaults to './...')
     type: string
     default: ./...
   test-opts:
-    description: go test options (Defaults to '-v -timeout 30s -race')
+    description: go test options (Defaults to '-v -timeout 30s')
     type: string
-    default: -v -timeout 30s -race
+    default: -v -timeout 30s
   version:
     description: version of golang to use (Defaults to 'latest'; must be a valid docker circleci/golang tag)
     type: string
@@ -43,7 +47,7 @@ steps:
         - checkout
   - go:
       pkg-spec: << parameters.pkg-spec >>
-      opts: test << parameters.test-opts >> <<# parameters.cover >> -coverprofile=coverage.out -covermode=<< parameters.covermode >><</ parameters.cover >>
+      opts: test << parameters.test-opts >> <<# parameters.race-detector >> -race <</ parameters.race-detector >> <<# parameters.cover >> -coverprofile=coverage.out -covermode=<< parameters.covermode >><</ parameters.cover >>
       cache: << parameters.cache >>
   - when:
       condition: << parameters.cover >>

--- a/src/golang/jobs/test.yml
+++ b/src/golang/jobs/test.yml
@@ -25,6 +25,10 @@ parameters:
     description: cover mode (Defaults to 'atomic')
     type: string
     default: atomic
+  race-detector:
+    description: Controls race detector (Defaults to 'true')
+    type: boolean
+    default: true
   install-postgresql-client:
     description: controls installation of the postgresql-client package (Defaults to 'true')
     type: boolean
@@ -58,9 +62,9 @@ parameters:
     type: string
     default: latest
   test-opts:
-    description: go test options (Defaults to '-v -timeout 30s -race')
+    description: go test options (Defaults to '-v -timeout 30s')
     type: string
-    default: -v -timeout 30s -race
+    default: -v -timeout 30s
   version:
     description: version of golang to use (Defaults to 'latest'; must be a valid docker circleci/golang tag)
     type: string
@@ -88,7 +92,7 @@ steps:
             version: << parameters.migration-version >>
   - go:
       pkg-spec: << parameters.pkg-spec >>
-      opts: test << parameters.test-opts >> <<# parameters.cover >> -coverprofile=coverage.out -covermode=<< parameters.covermode >><</ parameters.cover >>
+      opts: test << parameters.test-opts >> <<# parameters.race-detector >> -race <</ parameters.race-detector >> <<# parameters.cover >> -coverprofile=coverage.out -covermode=<< parameters.covermode >><</ parameters.cover >>
       cache: << parameters.cache >>
   - when:
       condition: << parameters.cover >>


### PR DESCRIPTION
It's particularly important to enable the race-detector in CI tests,
because it's able to catch and flag correctness issues which may not
show up for folks running vanilla `go test` locally.

It also seems likely that teams will tweak the default test options
(e.g., to increase the timeout) and accidentally remove the `-race` flag
without understanding the implications.

This extracts a new top-level config `race-detector` for tests which
controls the `-race` flag to call attention to its presence and make it
harder to accidentally remove.