### PR TITLE
New Orb: sfdx-evergreen-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Full documentation is on circle ci's site, linked below.
 * [heroku/install-sfdx](https://circleci.com/orbs/registry/orb/heroku/install-sfdx)
 * [heroku/golang](https://circleci.com/orbs/registry/orb/heroku/golang)
 * [heroku/sfdx-auth](https://circleci.com/orbs/registry/orb/heroku/sfdx-auth)
+* [heroku/sfdx-evergreen-auth](https://circleci.com/orbs/registry/orb/heroku/sfdx-evergreen-auth)
 * [heroku/snyk](https://circleci.com/orbs/registry/orb/heroku/snyk)
 * [heroku/terraform-for-test](https://circleci.com/orbs/registry/orb/heroku/terraform-for-test)
 

--- a/src/sfdx-evergreen-auth/@sfdx-evergreen-auth.yml
+++ b/src/sfdx-evergreen-auth/@sfdx-evergreen-auth.yml
@@ -1,0 +1,3 @@
+version: 2.1
+description: |
+  Authorize `sfdx evergreen` CLI via Evergreen Identity.

--- a/src/sfdx-evergreen-auth/commands/cleanup.yml
+++ b/src/sfdx-evergreen-auth/commands/cleanup.yml
@@ -1,5 +1,7 @@
 description: |
   Removes unencrypted credentials.
+
+  This command deletes the `~/.netrc` file, so be cautious where it is used to avoid conflicts with other usage of this shared credentials file.
 steps:
   - run:
       name: Clean-up sfdx evergreen auth

--- a/src/sfdx-evergreen-auth/commands/cleanup.yml
+++ b/src/sfdx-evergreen-auth/commands/cleanup.yml
@@ -1,0 +1,7 @@
+description: |
+  Removes unencrypted credentials.
+steps:
+  - run:
+      name: Clean-up sfdx evergreen auth
+      command: |
+        rm .netrc || true

--- a/src/sfdx-evergreen-auth/commands/setup.yml
+++ b/src/sfdx-evergreen-auth/commands/setup.yml
@@ -1,5 +1,7 @@
 description: |
   Authorizes sfdx evergreen CLI using the Evergreen Identity refresh token.
+
+  This command appends entries to `~/.netrc`, so be cautious how it is used to avoid conflicts with other usage of this shared credentials file. The appended Netrc "machine" entries are generated from the parameters `identity-hostname` & `api-hostname`.
 parameters:
   identity-hostname:
     type: string
@@ -28,7 +30,7 @@ steps:
           exit 2
         fi
 
-        echo $'machine << parameters.identity-hostname >>\n  password' "$EVERGREEN_REFRESH_TOKEN" > "$HOME/.netrc"
+        echo $'machine << parameters.identity-hostname >>\n  password' "$EVERGREEN_REFRESH_TOKEN" >> "$HOME/.netrc"
         echo $'machine << parameters.api-hostname >>\n  password' "placeholder" >> "$HOME/.netrc"
 
         echo "sfdx evergreen:whoami"

--- a/src/sfdx-evergreen-auth/commands/setup.yml
+++ b/src/sfdx-evergreen-auth/commands/setup.yml
@@ -1,0 +1,35 @@
+description: |
+  Authorizes sfdx evergreen CLI using the Evergreen Identity refresh token.
+parameters:
+  identity-hostname:
+    type: string
+    default: id.evergreen.salesforce.com
+  api-hostname:
+    type: string
+    default: lyra-edge-api.herokuapp.com
+steps:
+  - run:
+      name: Set-up sfdx evergreen auth
+      command: |
+        has_errors=false
+        if ! sfdx version; then
+          echo "Requires installation of sfdx: npm install sfdx-cli"
+          has_errors=true
+        fi
+        if ! sfdx evergreen; then
+          echo "Requires installation of sfdx evergreen plugin: sfdx plugins:install @salesforce/plugin-evergreen"
+          has_errors=true
+        fi
+        if [ -z "$EVERGREEN_REFRESH_TOKEN" ]; then
+          echo "Requires EVERGREEN_REFRESH_TOKEN environment variable"
+          has_errors=true
+        fi
+        if [ "$has_errors" = true ]; then
+          exit 2
+        fi
+
+        echo $'machine << parameters.identity-hostname >>\n  password' "$EVERGREEN_REFRESH_TOKEN" > "$HOME/.netrc"
+        echo $'machine << parameters.api-hostname >>\n  password' "placeholder" >> "$HOME/.netrc"
+
+        echo "sfdx evergreen:whoami"
+        sfdx evergreen:whoami


### PR DESCRIPTION
Extracting repetitive CircleCI configuration into an Orb:  
**Authorize `sfdx evergreen` CLI via Evergreen Identity.**