### PR TITLE
Update Evergreen auth for production API domain name

### DIFF
--- a/src/sfdx-evergreen-auth/commands/setup.yml
+++ b/src/sfdx-evergreen-auth/commands/setup.yml
@@ -8,7 +8,7 @@ parameters:
     default: id.evergreen.salesforce.com
   api-hostname:
     type: string
-    default: lyra-edge-api.herokuapp.com
+    default: api.evergreen.salesforce.com
 steps:
   - run:
       name: Set-up sfdx evergreen auth


### PR DESCRIPTION
Will release this Orb change as a new major version, since it will break existing usages until they are updated to use the new domain name, such as API client dependency.