### PR TITLE
add step that runs apt-get update

### DIFF
--- a/src/golang/commands/update-package-index.yml
+++ b/src/golang/commands/update-package-index.yml
@@ -1,0 +1,6 @@
+description: update package index
+steps:
+  - run:
+      name: update package index
+      command: |
+        sudo apt-get update

--- a/src/golang/jobs/test.yml
+++ b/src/golang/jobs/test.yml
@@ -41,6 +41,10 @@ parameters:
     description: Controls race detector (Defaults to 'true')
     type: boolean
     default: true
+  update-package-index:
+    description: Update package index (Defaults to 'true')
+    type: boolean
+    default: true
   install-postgresql-client:
     description: controls installation of the postgresql-client package (Defaults to 'true')
     type: boolean
@@ -134,6 +138,10 @@ steps:
                 echo
                 exit 1
               fi
+  - when:
+      condition: << parameters.update-package-index >>
+      steps:
+        - update-package-index
   - when:
       condition: << parameters.install-postgresql-client >>
       steps:


### PR DESCRIPTION
## Reasons for making these changes

The `test` job is currently failing when trying to install the redis tools

```
E: Failed to fetch http://security.debian.org/debian-security/pool/updates/main/r/redis/redis-tools_6.0.16-1%2bdeb11u1_amd64.deb  404  Not Found [IP: 146.75.34.132 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

## Description of changes

Adds a step that will run `sudo apt-get update` before it attempts to install postgres and redis tooling.
