### PR TITLE
Updating Snyk orb to fix download Snyk CLI

### DIFF
--- a/src/snyk/@snyk.yml
+++ b/src/snyk/@snyk.yml
@@ -2,4 +2,4 @@ version: 2.1
 description: |
   snyk orb
 orbs:
-  snyk: snyk/snyk@0.0.8
+  snyk: snyk/snyk@1.1.2


### PR DESCRIPTION
The old version of Snyk orb used cUrl to download the Snyk CLI client,
but something changed on GitHub that required adding the follow
redirects to that cUrl command. Checking the code of the latest version
of Snyk orb, that cUrl was changed to another URL. That will fix the
current issue and also keep us up to date.